### PR TITLE
【追加】会員情報検索API

### DIFF
--- a/SampleProject/app/Http/Controllers/Controller.php
+++ b/SampleProject/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Http\Request;
+
+class Controller
 {
     //
 }

--- a/SampleProject/app/Http/Controllers/MemberInfoController.php
+++ b/SampleProject/app/Http/Controllers/MemberInfoController.php
@@ -17,6 +17,7 @@ class MemberInfoController
         if (!is_array($fields))
             return response()->json(['message' => 'Invalid fields request.'], 400);
         $user_data = $user->only($fields);
+
         return response()->json($user_data, 200);
     }
 }

--- a/SampleProject/app/Http/Controllers/MemberInfoController.php
+++ b/SampleProject/app/Http/Controllers/MemberInfoController.php
@@ -14,7 +14,7 @@ class MemberInfoController
         if (!$user)
             return response()->json(['message' => 'No matching member information found'], 400);
         $fields = $request->input('fields', []);
-        if (!$fields || !is_array($fields))
+        if (!is_array($fields))
             return response()->json(['message' => 'Invalid fields request.'], 400);
         $user_data = $user->only($fields);
         return response()->json($user_data, 200);

--- a/SampleProject/app/Http/Controllers/MemberInfoController.php
+++ b/SampleProject/app/Http/Controllers/MemberInfoController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\User;
+
+class MemberInfoController
+{
+    public function find_and_return_member_info(Request $request)
+    {
+        $user_id = $request->cookie('user_id');
+        $user = User::where('user_id', $user_id)->first();
+        if (!$user)
+            return response()->json(['message' => 'No matching member information found'], 400);
+        $fields = $request->input('fields');
+        if (!$fields || !is_array($fields))
+            return response()->json(['message' => 'Invalid fields request.'], 400);
+        $user_data = $user->only($fields);
+        return response()->json($user_data, 200);
+    }
+}

--- a/SampleProject/app/Http/Controllers/MemberInfoController.php
+++ b/SampleProject/app/Http/Controllers/MemberInfoController.php
@@ -13,7 +13,7 @@ class MemberInfoController
         $user = User::where('user_id', $user_id)->first();
         if (!$user)
             return response()->json(['message' => 'No matching member information found'], 400);
-        $fields = $request->input('fields');
+        $fields = $request->input('fields', []);
         if (!$fields || !is_array($fields))
             return response()->json(['message' => 'Invalid fields request.'], 400);
         $user_data = $user->only($fields);

--- a/SampleProject/app/Http/Controllers/PasswordResetController.php
+++ b/SampleProject/app/Http/Controllers/PasswordResetController.php
@@ -26,7 +26,11 @@ class PasswordResetController extends Controller
         // send email
         Mail::to($request->email)->send(new PasswordResetEmail($reset_url));
 
-        return response()->json([
-            'message' => 'Password reset url sent successfully.'], 200);
+        return response()
+                ->json(
+                    [
+                        'message' => 'Password reset url sent successfully.'
+                    ],
+                    200);
     }
 }

--- a/SampleProject/app/Http/Controllers/PasswordResetController.php
+++ b/SampleProject/app/Http/Controllers/PasswordResetController.php
@@ -11,6 +11,8 @@ use App\Mail\PasswordResetEmail;
 
 class PasswordResetController extends Controller
 {
+    private const PASSWORD_RESET_URL = "http://localhost:8000/password-reset";
+
     public function send_password_reset_link(Request $request)
     {
         $email = $request->email;
@@ -22,7 +24,7 @@ class PasswordResetController extends Controller
                     ]);
 
         $token = Hash::make(Str::random(60));
-        $reset_url = 'http://localhost:8000/password-reset/'.$token;
+        $reset_url = self::PASSWORD_RESET_URL.$token;
         // send email
         Mail::to($request->email)->send(new PasswordResetEmail($reset_url));
 

--- a/SampleProject/app/Http/Controllers/PasswordResetController.php
+++ b/SampleProject/app/Http/Controllers/PasswordResetController.php
@@ -21,7 +21,7 @@ class PasswordResetController extends Controller
 
         $token = Hash::make(Str::random(60));
         $reset_url = 'http://localhost:8000/password-reset/'.$token;
-        //send email
+        // send email
         Mail::to($request->email)->send(new PasswordResetEmail($reset_url));
 
         return response()->json([

--- a/SampleProject/app/Http/Controllers/PasswordResetController.php
+++ b/SampleProject/app/Http/Controllers/PasswordResetController.php
@@ -16,8 +16,10 @@ class PasswordResetController extends Controller
         $email = $request->email;
         $user = User::where('email', $email)->first();
         if (!$user)
-            return response()->json([
-                'message' => 'This email address is not linked to a Uzone account']);
+            return response()
+                    ->json([
+                        'message' => 'This email address is not linked to a Uzone account'
+                    ]);
 
         $token = Hash::make(Str::random(60));
         $reset_url = 'http://localhost:8000/password-reset/'.$token;

--- a/SampleProject/app/Http/Controllers/PasswordResetController.php
+++ b/SampleProject/app/Http/Controllers/PasswordResetController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use App\Models\User;
+use App\Mail\PasswordResetEmail;
+
+class PasswordResetController extends Controller
+{
+    public function send_password_reset_link(Request $request)
+    {
+        $email = $request->email;
+        $user = User::where('email', $email)->first();
+        if (!$user)
+            return response()->json([
+                'message' => 'This email address is not linked to a Uzone account']);
+
+        $token = Hash::make(Str::random(60));
+        $reset_url = 'http://localhost:8000/password-reset/'.$token;
+        //send email
+        Mail::to($request->email)->send(new PasswordResetEmail($reset_url));
+
+        return response()->json([
+            'message' => 'Password reset url sent successfully.'], 200);
+    }
+}

--- a/SampleProject/app/Mail/PasswordResetEmail.php
+++ b/SampleProject/app/Mail/PasswordResetEmail.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PasswordResetEmail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $resetUrl;
+    /**
+     * Create a new message instance.
+     *
+     * @param string $code
+     */
+    public function __construct(string $resetUrl)
+    {
+        $this->resetUrl = $resetUrl;
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Password Reset Email',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.reset_url',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/SampleProject/resources/views/emails/reset_url.blade.php
+++ b/SampleProject/resources/views/emails/reset_url.blade.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Password Reset Url</title>
+</head>
+<body>
+	<p>Password reset url is: <strong>{{ $resetUrl}}</strong></p>
+	<p>This code is valid for 5 minutes.</p>
+</body>
+</html>
+

--- a/SampleProject/routes/api.php
+++ b/SampleProject/routes/api.php
@@ -7,7 +7,8 @@ use App\Http\Controllers\AuthCodesController;
 use App\Http\Controllers\AuthMailController;
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\PasswordChangeController;
-
+use App\Http\Controllers\PasswordResetController;
+use App\Http\Controllers\MemberInfoController;
 
 // Route::get('/user', function (Request $request) {
 //     return $request->user();
@@ -22,3 +23,7 @@ Route::get('/verify-email',[AuthMailController::class, 'verify_email_address']);
 Route::get('/login',[LoginController::class, 'login']);
 
 Route::get('/password-change',[PasswordChangeController::class, 'change_password']);
+
+Route::get('/password-reset',[PasswordResetController::class, 'send_password_reset_link']);
+
+Route::get('/membership-info',[MemberInfoController::class, 'find_and_return_member_info']);


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- チェックボックスは[x]のようにチェックします -->

# チケット
<!-- バックログチケット番号 -->
- [【追加】会員情報検索API](https://github.com/happyriku/partone_traning_program/issues/8)

# 対応内容
<!-- 変更の目的および詳細 -->
会員情報検索APIを作成した

# 参考文献
<!-- あれば -->

# 動作確認
<!-- どのように動作確認したか、すれば良いのか -->
<!-- 期待する動作でったのかスクショなど -->

1. Postmanで次のURLに`GET`を実行する
> `http://localhost:8000/api/membership-info`

情報は登録されているものとする

![スクリーンショット 2025-01-12 000324](https://github.com/user-attachments/assets/5611c760-af65-4614-a2e0-50a16b6c83f0)

# 主なレビューポイント
<!-- レビューで見てほしい点、注意点 -->

# TODO
<!-- このPRではカバーしていないTODOなど -->